### PR TITLE
Note repository

### DIFF
--- a/NoteCompositionService/src/main/java/com/revature/caliber/config/NoteCompositionServiceConfiguration.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/config/NoteCompositionServiceConfiguration.java
@@ -1,0 +1,13 @@
+package com.revature.caliber.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class NoteCompositionServiceConfiguration {
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Address.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Address.java
@@ -1,0 +1,145 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+public class Address implements Serializable {
+	private static final long serialVersionUID = -5649489166844504113L;
+
+	private int addressId;
+	private String street;
+	private String city;
+	private String state;
+	private String zipcode;
+	private String company;
+	private boolean active;
+
+	public Address() {
+		super();
+	}
+
+	public Address(int addressId, String street, String city, String state, String zipcode, String company,
+			boolean active) {
+		super();
+		this.addressId = addressId;
+		this.street = street;
+		this.city = city;
+		this.state = state;
+		this.zipcode = zipcode;
+		this.company = company;
+		this.active = active;
+	}
+
+	public int getAddressId() {
+		return addressId;
+	}
+
+	public void setAddressId(int addressId) {
+		this.addressId = addressId;
+	}
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public String getZipcode() {
+		return zipcode;
+	}
+
+	public void setZipcode(String zipcode) {
+		this.zipcode = zipcode;
+	}
+
+	public String getCompany() {
+		return company;
+	}
+
+	public void setCompany(String company) {
+		this.company = company;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (active ? 1231 : 1237);
+		result = prime * result + ((city == null) ? 0 : city.hashCode());
+		result = prime * result + ((company == null) ? 0 : company.hashCode());
+		result = prime * result + ((state == null) ? 0 : state.hashCode());
+		result = prime * result + ((street == null) ? 0 : street.hashCode());
+		result = prime * result + ((zipcode == null) ? 0 : zipcode.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Address other = (Address) obj;
+		if (active != other.active)
+			return false;
+		if (city == null) {
+			if (other.city != null)
+				return false;
+		} else if (!city.equals(other.city))
+			return false;
+		if (company == null) {
+			if (other.company != null)
+				return false;
+		} else if (!company.equals(other.company))
+			return false;
+		if (state == null) {
+			if (other.state != null)
+				return false;
+		} else if (!state.equals(other.state))
+			return false;
+		if (street == null) {
+			if (other.street != null)
+				return false;
+		} else if (!street.equals(other.street))
+			return false;
+		if (zipcode == null) {
+			if (other.zipcode != null)
+				return false;
+		} else if (!zipcode.equals(other.zipcode))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return company + ", " + street + " " + city + " " + state + " " + zipcode;
+	}
+
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Assessment.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Assessment.java
@@ -1,0 +1,149 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Assessment implements Serializable {
+	private static final long serialVersionUID = 1000816169523198151L;
+	private long assessmentId;
+	private String title;
+	private Batch batch;
+	private int rawScore;
+	private AssessmentType type;
+	private short week;
+	private Category category;
+	private Set<Grade> grades;
+
+	public Assessment() {
+		super();
+		this.grades = new HashSet<Grade>();
+	}
+
+	public Assessment(String title, Batch batch, int rawScore, AssessmentType type, short week, Category category,
+			Set<Grade> grades) {
+		this();
+		this.title = title;
+		this.batch = batch;
+		this.rawScore = rawScore;
+		this.type = type;
+		this.week = week;
+		this.category = category;
+	}
+
+	public long getAssessmentId() {
+		return assessmentId;
+	}
+
+	public void setAssessmentId(long assessmentId) {
+		this.assessmentId = assessmentId;
+	}
+
+	public String getTitle() {
+		return this.category.getSkillCategory() + " " + this.type.name();
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Batch getBatch() {
+		return batch;
+	}
+
+	public void setBatch(Batch batch) {
+		this.batch = batch;
+	}
+
+	public int getRawScore() {
+		return rawScore;
+	}
+
+	public void setRawScore(int rawScore) {
+		this.rawScore = rawScore;
+	}
+
+	public AssessmentType getType() {
+		return type;
+	}
+
+	public void setType(AssessmentType type) {
+		this.type = type;
+	}
+
+	public short getWeek() {
+		return week;
+	}
+
+	public void setWeek(short week) {
+		this.week = week;
+	}
+
+	public Category getCategory() {
+		return category;
+	}
+
+	public void setCategory(Category category) {
+		this.category = category;
+	}
+
+	public Set<Grade> getGrades() {
+		return grades;
+	}
+
+	public void setGrades(Set<Grade> grades) {
+		this.grades = grades;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((batch == null) ? 0 : batch.hashCode());
+		result = prime * result + ((category == null) ? 0 : category.hashCode());
+		result = prime * result + rawScore;
+		result = prime * result + ((title == null) ? 0 : title.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		result = prime * result + week;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Assessment other = (Assessment) obj;
+		if (batch == null) {
+			if (other.batch != null)
+				return false;
+		} else if (!batch.equals(other.batch))
+			return false;
+		if (category == null) {
+			if (other.category != null)
+				return false;
+		} else if (!category.equals(other.category))
+			return false;
+		if (rawScore != other.rawScore)
+			return false;
+		if (title == null) {
+			if (other.title != null)
+				return false;
+		} else if (!title.equals(other.title))
+			return false;
+		if (type != other.type)
+			return false;
+		if (week != other.week)
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Assessment [assessmentId=" + assessmentId + ", title=" + title + ", batch=" + batch + ", rawScore="
+				+ rawScore + ", type=" + type + ", week=" + week + ", category=" + category + "]";
+	}
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/AssessmentType.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/AssessmentType.java
@@ -1,0 +1,16 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum AssessmentType implements Serializable{
+	@JsonProperty("Exam")
+	Exam,
+	@JsonProperty("Verbal")
+	Verbal,
+	@JsonProperty("Project")
+	Project,
+	@JsonProperty("Other")
+	Other
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Batch.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Batch.java
@@ -1,0 +1,278 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Batch implements Serializable {
+	private static final long serialVersionUID = 5368888406682098953L;
+	
+	private int batchId;
+	private String resourceId;
+	private String trainingName;
+	private Trainer trainer;
+	private Trainer coTrainer;
+	private SkillType skillType;
+	private TrainingType trainingType;
+	private Date startDate;
+	private Date endDate;
+	private String location;
+	private Address address;
+	private short goodGradeThreshold;
+	private short borderlineGradeThreshold;
+	private Set<Trainee> trainees;
+	private int weeks;
+	private int gradedWeeks;
+	private Set<Note> notes;
+	
+	public Batch() {
+		super();
+		this.weeks = 1;
+		this.gradedWeeks = 7;
+		this.goodGradeThreshold = 80;
+		this.borderlineGradeThreshold = 70;
+		this.trainingType = TrainingType.Revature;
+		this.trainees = new HashSet<>();
+		this.notes = new HashSet<>();
+	}
+
+	/**
+	 * Constructor mostly used for testing. Defaults TrainingType - Revature,
+	 * SkillType - J2EE, Good grade - 80, and Borderline grade - 70
+	 *
+	 * @param trainingName
+	 * @param trainer
+	 * @param startDate
+	 * @param endDate
+	 * @param location
+	 */
+	public Batch(String trainingName, Trainer trainer, Date startDate, Date endDate, String location) {
+		this();
+		this.trainingName = trainingName;
+		this.trainer = trainer;
+		this.skillType = SkillType.J2EE;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.location = location;
+	}
+
+	public int getBatchId() {
+		return batchId;
+	}
+
+	public void setBatchId(int batchId) {
+		this.batchId = batchId;
+	}
+
+	public String getResourceId() {
+		return resourceId;
+	}
+
+	public void setResourceId(String resourceId) {
+		this.resourceId = resourceId;
+	}
+
+	public String getTrainingName() {
+		return trainingName;
+	}
+
+	public void setTrainingName(String trainingName) {
+		this.trainingName = trainingName;
+	}
+
+	public Trainer getTrainer() {
+		return trainer;
+	}
+
+	public void setTrainer(Trainer trainer) {
+		this.trainer = trainer;
+	}
+
+	public Trainer getCoTrainer() {
+		return coTrainer;
+	}
+
+	public void setCoTrainer(Trainer coTrainer) {
+		this.coTrainer = coTrainer;
+	}
+
+	public SkillType getSkillType() {
+		return skillType;
+	}
+
+	public void setSkillType(SkillType skillType) {
+		this.skillType = skillType;
+	}
+
+	public TrainingType getTrainingType() {
+		return trainingType;
+	}
+
+	public void setTrainingType(TrainingType trainingType) {
+		this.trainingType = trainingType;
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(String location) {
+		this.location = location;
+	}
+
+	public short getGoodGradeThreshold() {
+		return goodGradeThreshold;
+	}
+
+	public void setGoodGradeThreshold(short goodGradeThreshold) {
+		this.goodGradeThreshold = goodGradeThreshold;
+	}
+
+	public short getBorderlineGradeThreshold() {
+		return borderlineGradeThreshold;
+	}
+
+	public void setBorderlineGradeThreshold(short borderlineGradeThreshold) {
+		this.borderlineGradeThreshold = borderlineGradeThreshold;
+	}
+
+	public Set<Trainee> getTrainees() {
+		return trainees;
+	}
+
+	public void setTrainees(Set<Trainee> trainees) {
+		this.trainees = trainees;
+	}
+
+	public int getWeeks() {
+		return weeks;
+	}
+
+	public void setWeeks(int weeks) {
+		this.weeks = weeks;
+	}
+
+	public Set<Note> getNotes() {
+		return notes;
+	}
+
+	public void setNotes(Set<Note> notes) {
+		this.notes = notes;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+
+	public int getGradedWeeks() {
+		return gradedWeeks;
+	}
+
+	public void setGradedWeeks(int gradedWeeks) {
+		this.gradedWeeks = gradedWeeks;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + borderlineGradeThreshold;
+		result = prime * result + ((coTrainer == null) ? 0 : coTrainer.hashCode());
+		result = prime * result + ((endDate == null) ? 0 : endDate.hashCode());
+		result = prime * result + goodGradeThreshold;
+		result = prime * result + ((location == null) ? 0 : location.hashCode());
+		result = prime * result + ((skillType == null) ? 0 : skillType.hashCode());
+		result = prime * result + ((startDate == null) ? 0 : startDate.hashCode());
+		result = prime * result + ((trainer == null) ? 0 : trainer.hashCode());
+		result = prime * result + ((trainingName == null) ? 0 : trainingName.hashCode());
+		result = prime * result + ((trainingType == null) ? 0 : trainingType.hashCode());
+		result = prime * result + ((resourceId == null) ? 0 : resourceId.hashCode());
+		result = prime * result + weeks;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Batch other = (Batch) obj;
+		if (borderlineGradeThreshold != other.borderlineGradeThreshold)
+			return false;
+		if (coTrainer == null) {
+			if (other.coTrainer != null)
+				return false;
+		} else if (!coTrainer.equals(other.coTrainer))
+			return false;
+		if (endDate == null) {
+			if (other.endDate != null)
+				return false;
+		} else if (!endDate.equals(other.endDate))
+			return false;
+		if (goodGradeThreshold != other.goodGradeThreshold)
+			return false;
+		if (location == null) {
+			if (other.location != null)
+				return false;
+		} else if (!location.equals(other.location))
+			return false;
+		if (skillType != other.skillType)
+			return false;
+		if (startDate == null) {
+			if (other.startDate != null)
+				return false;
+		} else if (!startDate.equals(other.startDate))
+			return false;
+		if (trainer == null) {
+			if (other.trainer != null)
+				return false;
+		} else if (!trainer.equals(other.trainer))
+			return false;
+		if (trainingName == null) {
+			if (other.trainingName != null)
+				return false;
+		} else if (!trainingName.equals(other.trainingName))
+			return false;
+		if (resourceId == null) {
+			if (other.resourceId != null)
+				return false;
+		} else if (!resourceId.equals(other.resourceId))
+			return false;
+		if (trainingType != other.trainingType)
+			return false;
+		if (weeks != other.weeks)
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Batch [batchId=" + batchId + ", trainingName=" + trainingName + ", skillType=" + skillType
+				+ ", trainingType=" + trainingType +", location=" + location + "]";
+	}
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Category.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Category.java
@@ -1,0 +1,131 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class Category implements Serializable {
+	private static final long serialVersionUID = 8740866186523960143L;
+
+	private int categoryId;
+	private String skillCategory;
+	private boolean active;
+	private Set<Assessment> assessments;
+
+	/**
+	 * Instantiates a new Category.
+	 */
+	public Category() {
+		super();
+	}
+
+	/**
+	 * Create new category
+	 * 
+	 * @param skillCategory
+	 * @param active
+	 */
+	public Category(String skillCategory, boolean active) {
+		super();
+		this.skillCategory = skillCategory;
+		this.active = active;
+	}
+
+	/**
+	 * Gets category id.
+	 *
+	 * @return the category id
+	 */
+	public int getCategoryId() {
+		return categoryId;
+	}
+
+	/**
+	 * Sets category id.
+	 *
+	 * @param categoryId
+	 *            the category id
+	 */
+	public void setCategoryId(int categoryId) {
+		this.categoryId = categoryId;
+	}
+
+	/**
+	 * Gets skill category.
+	 *
+	 * @return the skill category
+	 */
+	public String getSkillCategory() {
+		return skillCategory;
+	}
+
+	/**
+	 * Sets skill category.
+	 *
+	 * @param skillCategory
+	 *            the skill category
+	 */
+	public void setSkillCategory(String skillCategory) {
+		this.skillCategory = skillCategory;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	/**
+	 * Gets assessments.
+	 *
+	 * @return the assessments
+	 */
+	public Set<Assessment> getAssessments() {
+		return assessments;
+	}
+
+	/**
+	 * Sets assessments.
+	 *
+	 * @param assessments
+	 *            the assessments
+	 */
+	public void setAssessments(Set<Assessment> assessments) {
+		this.assessments = assessments;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (active ? 1231 : 1237);
+		result = prime * result + ((skillCategory == null) ? 0 : skillCategory.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Category other = (Category) obj;
+		if (active != other.active)
+			return false;
+		if (skillCategory == null) {
+			if (other.skillCategory != null)
+				return false;
+		} else if (!skillCategory.equals(other.skillCategory))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return skillCategory;
+	}
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Grade.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Grade.java
@@ -1,0 +1,115 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class Grade implements Serializable {
+	private static final long serialVersionUID = -2020456497011531928L;
+
+	private long gradeId;
+	private Assessment assessment;
+	private Trainee trainee;
+	private Date dateReceived;
+	private double score;
+
+	public Grade() {
+		super();
+	}
+
+	public Grade(Assessment assessment, Trainee trainee, Date dateReceived, double score) {
+		super();
+		this.assessment = assessment;
+		this.trainee = trainee;
+		this.dateReceived = dateReceived;
+		this.score = score;
+	}
+
+	public long getGradeId() {
+		return gradeId;
+	}
+
+	public void setGradeId(long gradeId) {
+		this.gradeId = gradeId;
+	}
+
+	public Assessment getAssessment() {
+		return assessment;
+	}
+
+	public void setAssessment(Assessment assessment) {
+		this.assessment = assessment;
+	}
+
+	public Trainee getTrainee() {
+		return trainee;
+	}
+
+	public void setTrainee(Trainee trainee) {
+		this.trainee = trainee;
+	}
+
+	public Date getDateReceived() {
+		return dateReceived;
+	}
+
+	public void setDateReceived(Date dateReceived) {
+		this.dateReceived = dateReceived;
+	}
+
+	public double getScore() {
+		return score;
+	}
+
+	public void setScore(double score) {
+		this.score = score;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((assessment == null) ? 0 : assessment.hashCode());
+		result = prime * result + ((dateReceived == null) ? 0 : dateReceived.hashCode());
+		long temp;
+		temp = Double.doubleToLongBits(score);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		result = prime * result + ((trainee == null) ? 0 : trainee.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Grade other = (Grade) obj;
+		if (assessment == null) {
+			if (other.assessment != null)
+				return false;
+		} else if (!assessment.equals(other.assessment))
+			return false;
+		if (dateReceived == null) {
+			if (other.dateReceived != null)
+				return false;
+		} else if (!dateReceived.equals(other.dateReceived))
+			return false;
+		if (Double.doubleToLongBits(score) != Double.doubleToLongBits(other.score))
+			return false;
+		if (trainee == null) {
+			if (other.trainee != null)
+				return false;
+		} else if (!trainee.equals(other.trainee))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Grade [gradeId=" + gradeId + ", assessment=" + assessment + ", trainee=" + trainee + ", dateReceived="
+				+ dateReceived + ", score=" + score + "]";
+	}
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/InterviewFormat.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/InterviewFormat.java
@@ -1,0 +1,14 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum InterviewFormat implements Serializable{
+
+	@JsonProperty("Skype")
+	Skype,
+	@JsonProperty("Phone")
+	Phone
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Note.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Note.java
@@ -1,0 +1,298 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+public class Note implements Serializable {
+	private static final long serialVersionUID = 1203665277195505838L;
+	
+	private int noteId;
+	private String content;
+	private short week;
+	private Batch batch;
+	private Trainee trainee;
+	private TrainerRole maxVisibility;
+	private NoteType type;
+	private boolean qcFeedback;
+	private QCStatus qcStatus;
+	
+	public Note() {
+		super();
+		this.maxVisibility = TrainerRole.ROLE_TRAINER;
+	}
+	
+	/**
+	 * QC Status for the batch. Constructs the note and it's visibility If the
+	 * feedback is public, anyone can view. If not, the feedback can only be
+	 * viewed by QC and the VP.
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batch
+	 * @param maxVisibility
+	 * @param type
+	 * @param qcFeedback
+	 * @param qcStatus
+	 */
+	private Note(String content, short week, Batch batch, NoteType type, QCStatus qcStatus) {
+		this();
+		this.content = content;
+		this.week = week;
+		this.batch = batch;
+		if (type == NoteType.QC_BATCH)
+			this.maxVisibility = TrainerRole.ROLE_QC;
+		else
+			throw new IllegalArgumentException("Select proper NoteType");
+		this.type = type;
+		this.qcFeedback = true;
+		this.qcStatus = qcStatus;
+	}
+
+	/**
+	 * QC Status for each trainee. Constructs the note and it's visibility If
+	 * the feedback is public, anyone can view. If not, the feedback can only be
+	 * viewed by QC and the VP.
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batch
+	 * @param maxVisibility
+	 * @param type
+	 * @param qcFeedback
+	 * @param qcStatus
+	 */
+	private Note(String content, short week, Trainee trainee, NoteType type, QCStatus qcStatus) {
+		this();
+		this.content = content;
+		this.week = week;
+		this.trainee = trainee;
+		if (type == NoteType.QC_TRAINEE)
+			this.maxVisibility = TrainerRole.ROLE_QC;
+		else
+			throw new IllegalArgumentException("Select proper NoteType");
+		this.type = type;
+		this.qcFeedback = true;
+		this.qcStatus = qcStatus;
+	}
+
+	/**
+	 * Trainer feedback for a trainee
+	 * 
+	 * @param content
+	 * @param week
+	 * @param trainee
+	 * @param maxVisibility
+	 * @param type
+	 */
+	private Note(String content, short week, Trainee trainee) {
+		this();
+		this.content = content;
+		this.week = week;
+		this.trainee = trainee;
+		this.maxVisibility = TrainerRole.ROLE_TRAINER;
+		this.type = NoteType.TRAINEE;
+		this.qcFeedback = false;
+	}
+
+	/**
+	 * Trainer feedback for a batch
+	 * 
+	 * @param content
+	 * @param week
+	 * @param trainee
+	 * @param maxVisibility
+	 * @param type
+	 */
+	private Note(String content, short week, Batch batch) {
+		this();
+		this.content = content;
+		this.week = week;
+		this.batch = batch;
+		this.maxVisibility = TrainerRole.ROLE_TRAINER;
+		this.type = NoteType.BATCH;
+		this.qcFeedback = false;
+	}
+	
+	/**
+	 * Factory method to construct new QC weekly batch note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batch
+	 * @param qcStatus
+	 * @param isPublic
+	 * @return
+	 */
+	public static Note qcBatchNote(String content, Integer week, Batch batch, QCStatus qcStatus) {
+		return new Note(content, week.shortValue(), batch, NoteType.QC_BATCH, qcStatus);
+	}
+
+	/**
+	 * Factory method for creating new QC weekly individual trainee note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param trainee
+	 * @param qcStatus
+	 * @param isPublic
+	 * @return
+	 */
+	public static Note qcIndividualNote(String content, Integer week, Trainee trainee, QCStatus qcStatus) {
+		return new Note(content, week.shortValue(), trainee, NoteType.QC_TRAINEE, qcStatus);
+	}
+
+	/**
+	 * Factory method for creating a new Trainer weekly batch note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batch
+	 * @return
+	 */
+	public static Note trainerBatchNote(String content, Integer week, Batch batch) {
+		return new Note(content, week.shortValue(), batch);
+	}
+
+	/**
+	 * Factory method for creating a new Trainer weekly individual trainee note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param trainee
+	 * @return
+	 */
+	public static Note trainerIndividualNote(String content, Integer week, Trainee trainee) {
+		return new Note(content, week.shortValue(), trainee);
+	}
+
+	public int getNoteId() {
+		return noteId;
+	}
+
+	public void setNoteId(int noteId) {
+		this.noteId = noteId;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	public short getWeek() {
+		return week;
+	}
+
+	public void setWeek(short week) {
+		this.week = week;
+	}
+
+	public Batch getBatch() {
+		return batch;
+	}
+
+	public void setBatch(Batch batch) {
+		this.batch = batch;
+	}
+
+	public Trainee getTrainee() {
+		return trainee;
+	}
+
+	public void setTrainee(Trainee trainee) {
+		this.trainee = trainee;
+	}
+
+	public TrainerRole getMaxVisibility() {
+		return maxVisibility;
+	}
+
+	public void setMaxVisibility(TrainerRole maxVisibility) {
+		this.maxVisibility = maxVisibility;
+	}
+
+	public NoteType getType() {
+		return type;
+	}
+
+	public void setType(NoteType type) {
+		this.type = type;
+	}
+
+	public boolean isQcFeedback() {
+		return qcFeedback;
+	}
+
+	public void setQcFeedback(boolean qcFeedback) {
+		this.qcFeedback = qcFeedback;
+	}
+
+	public QCStatus getQcStatus() {
+		return qcStatus;
+	}
+
+	public void setQcStatus(QCStatus qcStatus) {
+		this.qcStatus = qcStatus;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((batch == null) ? 0 : batch.hashCode());
+		result = prime * result + ((content == null) ? 0 : content.hashCode());
+		result = prime * result + ((maxVisibility == null) ? 0 : maxVisibility.hashCode());
+		result = prime * result + (qcFeedback ? 1231 : 1237);
+		result = prime * result + ((qcStatus == null) ? 0 : qcStatus.hashCode());
+		result = prime * result + ((trainee == null) ? 0 : trainee.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		result = prime * result + week;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Note other = (Note) obj;
+		if (batch == null) {
+			if (other.batch != null)
+				return false;
+		} else if (!batch.equals(other.batch))
+			return false;
+		if (content == null) {
+			if (other.content != null)
+				return false;
+		} else if (!content.equals(other.content))
+			return false;
+		if (maxVisibility != other.maxVisibility)
+			return false;
+		if (qcFeedback != other.qcFeedback)
+			return false;
+		if (qcStatus != other.qcStatus)
+			return false;
+		if (trainee == null) {
+			if (other.trainee != null)
+				return false;
+		} else if (!trainee.equals(other.trainee))
+			return false;
+		if (type != other.type)
+			return false;
+		if (week != other.week)
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Note [noteId=" + noteId + ", content=" + content + ", week=" + week
+				+ ", trainee=" + trainee + ", maxVisibility=" + maxVisibility + ", type=" + type
+				+ ", qcFeedback=" + qcFeedback + ", qcStatus=" + qcStatus + "]";
+	}
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/NoteType.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/NoteType.java
@@ -1,0 +1,25 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Determines if notes are created by Trainer or QC 
+ * and where they are applied (to the trainee or batch).
+ * Public notes are made by QC that are not visible to trainers and below.
+ * 
+ * @author Patrick Walsh
+ *
+ */
+
+public enum NoteType implements Serializable {
+	@JsonProperty("TRAINEE")
+	TRAINEE,
+	@JsonProperty("BATCH")
+	BATCH,
+	@JsonProperty("QC_TRAINEE")
+	QC_TRAINEE,
+	@JsonProperty("QC_BATCH")
+	QC_BATCH
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Panel.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Panel.java
@@ -1,0 +1,291 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Set;
+
+public class Panel implements Serializable {
+	private static final long serialVersionUID = -3904962254572382770L;
+	
+	private int id;
+	private Trainee trainee;
+	private Trainer panelist;
+	private Date interviewDate;
+	private String duration;
+	private InterviewFormat format;
+	private String internet;
+	private int panelRound;
+	private boolean recordingConsent;
+	private String recordingLink;
+	private PanelStatus status;
+	private Set<PanelFeedback> feedback;
+	private String associateIntro;
+	private String projectOneDescription;
+	private String projectTwoDescription;
+	private String projectThreeDescription;
+	private String communicationSkills;
+	private String overall;
+	
+	public Panel() {
+		super();
+		this.interviewDate = new Date();
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Trainee getTrainee() {
+		return trainee;
+	}
+
+	public void setTrainee(Trainee trainee) {
+		this.trainee = trainee;
+	}
+
+	public Trainer getPanelist() {
+		return panelist;
+	}
+
+	public void setPanelist(Trainer panelist) {
+		this.panelist = panelist;
+	}
+
+	public Date getInterviewDate() {
+		return interviewDate;
+	}
+
+	public void setInterviewDate(Date interviewDate) {
+		this.interviewDate = interviewDate;
+	}
+
+	public String getDuration() {
+		return duration;
+	}
+
+	public void setDuration(String duration) {
+		this.duration = duration;
+	}
+
+	public InterviewFormat getFormat() {
+		return format;
+	}
+
+	public void setFormat(InterviewFormat format) {
+		this.format = format;
+	}
+
+	public String getInternet() {
+		return internet;
+	}
+
+	public void setInternet(String internet) {
+		this.internet = internet;
+	}
+
+	public int getPanelRound() {
+		return panelRound;
+	}
+
+	public void setPanelRound(int panelRound) {
+		this.panelRound = panelRound;
+	}
+
+	public boolean isRecordingConsent() {
+		return recordingConsent;
+	}
+
+	public void setRecordingConsent(boolean recordingConsent) {
+		this.recordingConsent = recordingConsent;
+	}
+
+	public String getRecordingLink() {
+		return recordingLink;
+	}
+
+	public void setRecordingLink(String recordingLink) {
+		this.recordingLink = recordingLink;
+	}
+
+	public PanelStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(PanelStatus status) {
+		this.status = status;
+	}
+
+	public Set<PanelFeedback> getFeedback() {
+		return feedback;
+	}
+
+	public void setFeedback(Set<PanelFeedback> feedback) {
+		this.feedback = feedback;
+	}
+
+	public String getAssociateIntro() {
+		return associateIntro;
+	}
+
+	public void setAssociateIntro(String associateIntro) {
+		this.associateIntro = associateIntro;
+	}
+
+	public String getProjectOneDescription() {
+		return projectOneDescription;
+	}
+
+	public void setProjectOneDescription(String projectOneDescription) {
+		this.projectOneDescription = projectOneDescription;
+	}
+
+	public String getProjectTwoDescription() {
+		return projectTwoDescription;
+	}
+
+	public void setProjectTwoDescription(String projectTwoDescription) {
+		this.projectTwoDescription = projectTwoDescription;
+	}
+
+	public String getProjectThreeDescription() {
+		return projectThreeDescription;
+	}
+
+	public void setProjectThreeDescription(String projectThreeDescription) {
+		this.projectThreeDescription = projectThreeDescription;
+	}
+
+	public String getCommunicationSkills() {
+		return communicationSkills;
+	}
+
+	public void setCommunicationSkills(String communicationSkills) {
+		this.communicationSkills = communicationSkills;
+	}
+
+	public String getOverall() {
+		return overall;
+	}
+
+	public void setOverall(String overall) {
+		this.overall = overall;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((associateIntro == null) ? 0 : associateIntro.hashCode());
+		result = prime * result + ((communicationSkills == null) ? 0 : communicationSkills.hashCode());
+		result = prime * result + ((duration == null) ? 0 : duration.hashCode());
+		result = prime * result + ((format == null) ? 0 : format.hashCode());
+		result = prime * result + ((internet == null) ? 0 : internet.hashCode());
+		result = prime * result + ((interviewDate == null) ? 0 : interviewDate.hashCode());
+		result = prime * result + ((overall == null) ? 0 : overall.hashCode());
+		result = prime * result + panelRound;
+		result = prime * result + ((panelist == null) ? 0 : panelist.hashCode());
+		result = prime * result + ((projectOneDescription == null) ? 0 : projectOneDescription.hashCode());
+		result = prime * result + ((projectThreeDescription == null) ? 0 : projectThreeDescription.hashCode());
+		result = prime * result + ((projectTwoDescription == null) ? 0 : projectTwoDescription.hashCode());
+		result = prime * result + (recordingConsent ? 1231 : 1237);
+		result = prime * result + ((recordingLink == null) ? 0 : recordingLink.hashCode());
+		result = prime * result + ((status == null) ? 0 : status.hashCode());
+		result = prime * result + ((trainee == null) ? 0 : trainee.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Panel other = (Panel) obj;
+		if (associateIntro == null) {
+			if (other.associateIntro != null)
+				return false;
+		} else if (!associateIntro.equals(other.associateIntro))
+			return false;
+		if (communicationSkills == null) {
+			if (other.communicationSkills != null)
+				return false;
+		} else if (!communicationSkills.equals(other.communicationSkills))
+			return false;
+		if (duration == null) {
+			if (other.duration != null)
+				return false;
+		} else if (!duration.equals(other.duration))
+			return false;
+		if (format != other.format)
+			return false;
+		if (internet == null) {
+			if (other.internet != null)
+				return false;
+		} else if (!internet.equals(other.internet))
+			return false;
+		if (interviewDate == null) {
+			if (other.interviewDate != null)
+				return false;
+		} else if (!interviewDate.equals(other.interviewDate))
+			return false;
+		if (overall == null) {
+			if (other.overall != null)
+				return false;
+		} else if (!overall.equals(other.overall))
+			return false;
+		if (panelRound != other.panelRound)
+			return false;
+		if (panelist == null) {
+			if (other.panelist != null)
+				return false;
+		} else if (!panelist.equals(other.panelist))
+			return false;
+		if (projectOneDescription == null) {
+			if (other.projectOneDescription != null)
+				return false;
+		} else if (!projectOneDescription.equals(other.projectOneDescription))
+			return false;
+		if (projectThreeDescription == null) {
+			if (other.projectThreeDescription != null)
+				return false;
+		} else if (!projectThreeDescription.equals(other.projectThreeDescription))
+			return false;
+		if (projectTwoDescription == null) {
+			if (other.projectTwoDescription != null)
+				return false;
+		} else if (!projectTwoDescription.equals(other.projectTwoDescription))
+			return false;
+		if (recordingConsent != other.recordingConsent)
+			return false;
+		if (recordingLink == null) {
+			if (other.recordingLink != null)
+				return false;
+		} else if (!recordingLink.equals(other.recordingLink))
+			return false;
+		if (status != other.status)
+			return false;
+		if (trainee == null) {
+			if (other.trainee != null)
+				return false;
+		} else if (!trainee.equals(other.trainee))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Panel [id=" + id + ", trainee=" + trainee + ", panelist=" + panelist + ", interviewDate="
+				+ interviewDate + ", duration=" + duration + ", format=" + format + ", internet=" + internet
+				+ ", panelRound=" + panelRound + ", recordingConsent=" + recordingConsent + ", recordingLink="
+				+ recordingLink + ", status=" + status + ", feedback=" + feedback + ", associateIntro=" + associateIntro
+				+ ", projectOneDescription=" + projectOneDescription + ", projectTwoDescription="
+				+ projectTwoDescription + ", projectThreeDescription=" + projectThreeDescription
+				+ ", communicationSkills=" + communicationSkills + ", overall=" + overall + "]";
+	}
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/PanelFeedback.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/PanelFeedback.java
@@ -1,0 +1,115 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+public class PanelFeedback implements Serializable {
+	private static final long serialVersionUID = -7997716749941674836L;
+	
+	private long id;
+	private Category technology;
+	private PanelStatus status;
+	private int result;
+	private String comment;
+	private Panel panel;
+	
+	public PanelFeedback() {
+		super();
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Category getTechnology() {
+		return technology;
+	}
+
+	public void setTechnology(Category technology) {
+		this.technology = technology;
+	}
+
+	public PanelStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(PanelStatus status) {
+		this.status = status;
+	}
+
+	public int getResult() {
+		return result;
+	}
+
+	public void setResult(int result) {
+		this.result = result;
+	}
+
+	public String getComment() {
+		return comment;
+	}
+
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	public Panel getPanel() {
+		return panel;
+	}
+
+	public void setPanel(Panel panel) {
+		this.panel = panel;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int hashCodeResult = 1;
+		hashCodeResult = prime * hashCodeResult + ((comment == null) ? 0 : comment.hashCode());
+		hashCodeResult = prime * hashCodeResult + ((panel == null) ? 0 : panel.hashCode());
+		hashCodeResult = prime * hashCodeResult + this.result;
+		hashCodeResult = prime * hashCodeResult + ((status == null) ? 0 : status.hashCode());
+		hashCodeResult = prime * hashCodeResult + ((technology == null) ? 0 : technology.hashCode());
+		return hashCodeResult;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PanelFeedback other = (PanelFeedback) obj;
+		if (comment == null) {
+			if (other.comment != null)
+				return false;
+		} else if (!comment.equals(other.comment))
+			return false;
+		if (panel == null) {
+			if (other.panel != null)
+				return false;
+		} 
+		if (result != other.result)
+			return false;
+		if (status != other.status)
+			return false;
+		if (technology == null) {
+			if (other.technology != null)
+				return false;
+		} else if (!technology.equals(other.technology))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "PanelFeedback [id=" + id + ", technology=" + technology + ", status=" + status + ", result=" + result
+				+ ", comment=" + comment + "]";
+	}
+	
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/PanelStatus.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/PanelStatus.java
@@ -1,0 +1,18 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Designates if the associate passed/failed the panel
+ * or passed/failed a particular topic.
+ * @author Patrick Walsh
+ *
+ */
+public enum PanelStatus implements Serializable{
+		@JsonProperty("Pass")
+		Pass,
+		@JsonProperty("Repanel")
+		Repanel
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/QCStatus.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/QCStatus.java
@@ -1,0 +1,23 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Imported from Caliber
+ */
+
+
+public enum QCStatus implements Serializable {
+	@JsonProperty("Superstar")
+	Superstar,
+	@JsonProperty("Good")
+	Good,
+	@JsonProperty("Average")
+	Average,
+	@JsonProperty("Poor")
+	Poor,
+	@JsonProperty("Undefined")
+	Undefined
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/SimpleNote.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/SimpleNote.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Table(name = "CALIBER_NOTE")
-public class Note implements Serializable {
+public class SimpleNote implements Serializable {
 	private static final long serialVersionUID = 7785756076682011103L;
 
 	@Id
@@ -57,7 +57,7 @@ public class Note implements Serializable {
 	@Column(name = "QC_STATUS", nullable = true)
 	private QCStatus qcStatus;
 
-	public Note() {
+	public SimpleNote() {
 		super();
 		this.maxVisibility = TrainerRole.ROLE_TRAINER;
 	}
@@ -71,8 +71,8 @@ public class Note implements Serializable {
 	 * @param qcStatus
 	 * @return
 	 */
-	public static Note qcBatchNote(String content, Short week, Integer batchId, QCStatus qcStatus) {
-		Note note = new Note();
+	public static SimpleNote qcBatchNote(String content, Short week, Integer batchId, QCStatus qcStatus) {
+		SimpleNote note = new SimpleNote();
 		
 		note.setContent(content);
 		note.setWeek(week);
@@ -94,8 +94,8 @@ public class Note implements Serializable {
 	 * @param qcStatus
 	 * @return
 	 */
-	public static Note qcIndividualNote(String content, Short week, Integer traineeId, QCStatus qcStatus) {
-		Note note = new Note();
+	public static SimpleNote qcIndividualNote(String content, Short week, Integer traineeId, QCStatus qcStatus) {
+		SimpleNote note = new SimpleNote();
 		
 		note.setContent(content);
 		note.setWeek(week);
@@ -116,8 +116,8 @@ public class Note implements Serializable {
 	 * @param batchId
 	 * @return
 	 */
-	public static Note trainerBatchNote(String content, Short week, Integer batchId) {
-		Note note = new Note();
+	public static SimpleNote trainerBatchNote(String content, Short week, Integer batchId) {
+		SimpleNote note = new SimpleNote();
 		
 		note.setContent(content);
 		note.setWeek(week);
@@ -137,8 +137,8 @@ public class Note implements Serializable {
 	 * @param traineeId
 	 * @return
 	 */
-	public static Note trainerIndividualNote(String content, Short week, Integer traineeId) {
-		Note note = new Note();
+	public static SimpleNote trainerIndividualNote(String content, Short week, Integer traineeId) {
+		SimpleNote note = new SimpleNote();
 		
 		note.setContent(content);
 		note.setWeek(week);
@@ -246,7 +246,7 @@ public class Note implements Serializable {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		Note other = (Note) obj;
+		SimpleNote other = (SimpleNote) obj;
 		if (batchId == null) {
 			if (other.batchId != null)
 				return false;

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/SkillType.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/SkillType.java
@@ -1,0 +1,34 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SkillType implements Serializable{
+	@JsonProperty("J2EE")
+	J2EE("J2EE"),
+	@JsonProperty(".NET")
+	NET(".NET"),
+	@JsonProperty("SDET")
+	SDET("SDET"),
+	@JsonProperty("BPM")
+	BPM("BPM"),
+	@JsonProperty("Other")
+	OTHER("Other");
+	
+	private String type;
+
+	private SkillType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public String toString() {
+		return type;
+	}
+
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Trainee.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Trainee.java
@@ -1,0 +1,256 @@
+package com.revature.caliber.model;
+
+import java.awt.Panel;
+import java.io.Serializable;
+import java.util.Set;
+
+public class Trainee implements Serializable {
+	private static final long serialVersionUID = -6103923098134644806L;
+	
+	private int traineeId;
+	private String resourceId;
+	private String name;
+	private String email;
+	private TrainingStatus trainingStatus;
+	private Batch batch;
+	private String phoneNumber;
+	private String skypeId;
+	private String profileUrl;
+	private String recruiterName;
+	private String college;
+	private String degree;
+	private String major;
+	private String techScreenerName;
+	private String projectCompletion;
+	private Set<Grade> grades;
+	private Set<Note> notes;
+	private Set<Panel> panelInterviews;
+	
+	public Trainee() {
+		super();
+	}
+
+	/**
+	 * Constructor used mostly for testing. Default TrainingStatus as Training
+	 * @param name
+	 * @param resourceId
+	 * @param email
+	 * @param batch
+	 */
+	public Trainee(String name, String resourceId, String email, Batch batch) {
+		super();
+		this.name = name;
+		this.resourceId = resourceId;
+		this.email = email;
+		this.trainingStatus = TrainingStatus.Training;
+		this.batch = batch;
+	}
+
+	public int getTraineeId() {
+		return traineeId;
+	}
+
+	public void setTraineeId(int traineeId) {
+		this.traineeId = traineeId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public TrainingStatus getTrainingStatus() {
+		return trainingStatus;
+	}
+
+	public void setTrainingStatus(TrainingStatus trainingStatus) {
+		this.trainingStatus = trainingStatus;
+	}
+
+	public Batch getBatch() {
+		return batch;
+	}
+
+	public void setBatch(Batch batch) {
+		this.batch = batch;
+	}
+
+	public Set<Grade> getGrades() {
+		return grades;
+	}
+
+	public void setGrades(Set<Grade> grades) {
+		this.grades = grades;
+	}
+
+	public Set<Note> getNotes() {
+		return notes;
+	}
+
+	public void setNotes(Set<Note> notes) {
+		this.notes = notes;
+	}
+
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+
+	public void setPhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	public String getSkypeId() {
+		return skypeId;
+	}
+
+	public void setSkypeId(String skypeId) {
+		this.skypeId = skypeId;
+	}
+
+	public String getProfileUrl() {
+		return profileUrl;
+	}
+
+	public void setProfileUrl(String profileUrl) {
+		this.profileUrl = profileUrl;
+	}
+
+	public String getResourceId() {
+		return resourceId;
+	}
+
+	public void setResourceId(String resourceId) {
+		this.resourceId = resourceId;
+	}
+
+	public Set<Panel> getPanelInterviews() {
+		return panelInterviews;
+	}
+
+	public void setPanelInterviews(Set<Panel> panelInterviews) {
+		this.panelInterviews = panelInterviews;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((email == null) ? 0 : email.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((phoneNumber == null) ? 0 : phoneNumber.hashCode());
+		result = prime * result + ((profileUrl == null) ? 0 : profileUrl.hashCode());
+		result = prime * result + ((skypeId == null) ? 0 : skypeId.hashCode());
+		result = prime * result + ((trainingStatus == null) ? 0 : trainingStatus.hashCode());
+		result = prime * result + ((resourceId == null) ? 0 : resourceId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Trainee other = (Trainee) obj;
+		if (email == null) {
+			if (other.email != null)
+				return false;
+		} else if (!email.equals(other.email))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (phoneNumber == null) {
+			if (other.phoneNumber != null)
+				return false;
+		} else if (!phoneNumber.equals(other.phoneNumber))
+			return false;
+		if (profileUrl == null) {
+			if (other.profileUrl != null)
+				return false;
+		} else if (!profileUrl.equals(other.profileUrl))
+			return false;
+		if (skypeId == null) {
+			if (other.skypeId != null)
+				return false;
+		} else if (!skypeId.equals(other.skypeId))
+			return false;
+		if (trainingStatus != other.trainingStatus)
+			return false;
+		if (resourceId == null) {
+			if (other.resourceId != null)
+				return false;
+		} else if (!resourceId.equals(other.resourceId))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Trainee [traineeId=" + traineeId +", name=" + name + ", email=" + email + ", trainingStatus="
+				+ trainingStatus + ", major=" + major +  "]";
+	}
+
+	public String getRecruiterName() {
+		return recruiterName;
+	}
+
+	public void setRecruiterName(String recruiterName) {
+		this.recruiterName = recruiterName;
+	}
+
+	public String getCollege() {
+		return college;
+	}
+
+	public void setCollege(String college) {
+		this.college = college;
+	}
+
+	public String getDegree() {
+		return degree;
+	}
+
+	public void setDegree(String degree) {
+		this.degree = degree;
+	}
+
+	public String getMajor() {
+		return major;
+	}
+
+	public void setMajor(String major) {
+		this.major = major;
+	}
+
+	public String getTechScreenerName() {
+		return techScreenerName;
+	}
+
+	public void setTechScreenerName(String techScreenerName) {
+		this.techScreenerName = techScreenerName;
+	}
+
+	public String getProjectCompletion() {
+		return projectCompletion;
+	}
+
+	public void setProjectCompletion(String projectCompletion) {
+		this.projectCompletion = projectCompletion;
+	}
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/Trainer.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/Trainer.java
@@ -1,0 +1,5 @@
+package com.revature.caliber.model;
+
+public class Trainer {
+
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainerRole.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainerRole.java
@@ -1,0 +1,31 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * System access roles. 
+ * 
+ * *****Listed in order of precedence descending******
+ * 
+ * @author Patrick Walsh
+ * @author Stanley Chouloute
+ * @author Adam Baker
+ *
+ */
+
+public enum TrainerRole implements Serializable {
+	@JsonProperty("ROLE_VP")
+	ROLE_VP,
+	@JsonProperty("ROLE_PANEL")
+	ROLE_PANEL,
+	@JsonProperty("ROLE_QC")
+	ROLE_QC,
+	@JsonProperty("ROLE_TRAINER")
+	ROLE_TRAINER,
+	@JsonProperty("ROLE_STAGING")
+	ROLE_STAGING,
+	@JsonProperty("ROLE_INACTIVE")
+	ROLE_INACTIVE
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainingStatus.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainingStatus.java
@@ -1,0 +1,22 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum TrainingStatus implements Serializable{
+	@JsonProperty("Signed")
+	Signed,
+	@JsonProperty("Selected")
+	Selected,
+	@JsonProperty("Training")
+	Training,
+	@JsonProperty("Marketing")
+	Marketing,
+	@JsonProperty("Confirmed")
+	Confirmed,
+	@JsonProperty("Employed")
+	Employed,
+	@JsonProperty("Dropped")
+	Dropped
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainingType.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/model/TrainingType.java
@@ -1,0 +1,16 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum TrainingType implements Serializable {
+	@JsonProperty("Revature")
+	Revature,
+	@JsonProperty("Corporate")
+	Corporate,
+	@JsonProperty("University")
+	University,
+	@JsonProperty("Other")
+	Other
+}

--- a/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionMessagingService.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionMessagingService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class NoteCompositionMessagingService {
-	@RabbitListener(queues = "caliber.queue")
+	@RabbitListener(queues = "caliber.note")
 	public String receive(String message) {
 		System.out.println(message);
 		return "NoteCompositionMessagingService is ready";

--- a/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionService.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionService.java
@@ -1,17 +1,25 @@
 package com.revature.caliber.service;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
+import com.revature.caliber.model.Note;
 import com.revature.caliber.model.SimpleNote;
 
+@RestController
+@RequestMapping(value = "/note")
 public class NoteCompositionService {
 	@Autowired
 	private RestTemplate restTemplate;
 	
-	public List<SimpleNote> findTraineeNote() {
+	@GetMapping(value = "/{traineeId}/{week}")
+	public SimpleNote findTraineeNote(@PathVariable("traineeId") int traineeId, @PathVariable("week") short week) {
+		SimpleNote simpleTraineeNote = restTemplate.getForObject("http://localhost:8180/note/" + traineeId + "/" + week, SimpleNote.class);
 		
+		return simpleTraineeNote;
 	}
 }

--- a/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionService.java
+++ b/NoteCompositionService/src/main/java/com/revature/caliber/service/NoteCompositionService.java
@@ -1,5 +1,17 @@
 package com.revature.caliber.service;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.client.RestTemplate;
+
+import com.revature.caliber.model.SimpleNote;
+
 public class NoteCompositionService {
+	@Autowired
+	private RestTemplate restTemplate;
 	
+	public List<SimpleNote> findTraineeNote() {
+		
+	}
 }

--- a/NoteCompositionService/src/main/resources/application.properties
+++ b/NoteCompositionService/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+server.port=8182
+
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/controller/NoteRepositoryRestController.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/controller/NoteRepositoryRestController.java
@@ -1,0 +1,27 @@
+package com.revature.caliber.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.revature.caliber.model.SimpleNote;
+import com.revature.caliber.repository.NoteRepository;
+
+@RestController
+@RequestMapping(value = "/note")
+public class NoteRepositoryRestController {
+	
+	@Autowired
+	private NoteRepository noteRepository;
+	
+	@GetMapping(value = "/all")
+	public ResponseEntity<List<SimpleNote>> getAllNotes() {
+		List<SimpleNote> notes = noteRepository.findAll();
+		return new ResponseEntity<List<SimpleNote>>(notes, HttpStatus.OK);
+	}
+}

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/controller/NoteRepositoryRestController.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/controller/NoteRepositoryRestController.java
@@ -6,9 +6,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.revature.caliber.model.NoteType;
 import com.revature.caliber.model.SimpleNote;
 import com.revature.caliber.repository.NoteRepository;
 
@@ -23,5 +25,12 @@ public class NoteRepositoryRestController {
 	public ResponseEntity<List<SimpleNote>> getAllNotes() {
 		List<SimpleNote> notes = noteRepository.findAll();
 		return new ResponseEntity<List<SimpleNote>>(notes, HttpStatus.OK);
+	}
+	
+	@GetMapping(value = "/{traineeId}/{week}")
+	public SimpleNote findTraineeNote(@PathVariable("traineeId") int traineeId, @PathVariable("week") short week) {
+		SimpleNote simpleTraineeNote = noteRepository.findByTraineeIdAndWeekAndQcFeedbackAndType(traineeId, week, false, NoteType.TRAINEE);
+		
+		return simpleTraineeNote;
 	}
 }

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/model/SimpleNote.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/model/SimpleNote.java
@@ -1,0 +1,293 @@
+package com.revature.caliber.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+
+@Entity
+@Table(name = "CALIBER_NOTE")
+public class SimpleNote implements Serializable {
+	private static final long serialVersionUID = 7785756076682011103L;
+
+	@Id
+	@Column(name = "NOTE_ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "NOTE_ID_SEQUENCE")
+	@SequenceGenerator(name = "NOTE_ID_SEQUENCE", sequenceName = "NOTE_ID_SEQUENCE")
+	private Integer noteId;
+
+	@Length(min = 0, max = 4000)
+	@Column(name = "NOTE_CONTENT")
+	private String content;
+
+	@Min(value = 1)
+	@Column(name = "WEEK_NUMBER")
+	private Short week;
+
+	@Column(name = "BATCH_ID", nullable = true)
+	private Integer batchId;
+
+	@Column(name = "TRAINEE_ID", nullable = true)
+	private Integer traineeId;
+
+	@Enumerated(EnumType.ORDINAL)
+	@Column(name = "MAX_VISIBILITY")
+	private TrainerRole maxVisibility;
+
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	@Column(name = "NOTE_TYPE")
+	private NoteType type;
+
+	@Column(name = "IS_QC_FEEDBACK", nullable = false)
+	private boolean qcFeedback;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "QC_STATUS", nullable = true)
+	private QCStatus qcStatus;
+
+	public SimpleNote() {
+		super();
+		this.maxVisibility = TrainerRole.ROLE_TRAINER;
+	}
+	
+	/**
+	 * Factory method to construct new QC weekly batch note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batchId
+	 * @param qcStatus
+	 * @return
+	 */
+	public static SimpleNote qcBatchNote(String content, Short week, Integer batchId, QCStatus qcStatus) {
+		SimpleNote note = new SimpleNote();
+		
+		note.setContent(content);
+		note.setWeek(week);
+		note.setBatchId(batchId);
+		note.setMaxVisibility(TrainerRole.ROLE_QC);
+		note.setType(NoteType.QC_BATCH);
+		note.setQcFeedback(true);
+		note.setQcStatus(qcStatus);
+		
+		return note;
+	}
+	
+	/**
+	 * Factory method for creating new QC weekly individual trainee note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param traineeId
+	 * @param qcStatus
+	 * @return
+	 */
+	public static SimpleNote qcIndividualNote(String content, Short week, Integer traineeId, QCStatus qcStatus) {
+		SimpleNote note = new SimpleNote();
+		
+		note.setContent(content);
+		note.setWeek(week);
+		note.setTraineeId(traineeId);
+		note.setMaxVisibility(TrainerRole.ROLE_QC);
+		note.setType(NoteType.QC_TRAINEE);
+		note.setQcFeedback(true);
+		note.setQcStatus(qcStatus);;
+		
+		return note;
+	}
+	
+	/**
+	 * Factory method for creating a new Trainer weekly batch note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param batchId
+	 * @return
+	 */
+	public static SimpleNote trainerBatchNote(String content, Short week, Integer batchId) {
+		SimpleNote note = new SimpleNote();
+		
+		note.setContent(content);
+		note.setWeek(week);
+		note.setBatchId(batchId);
+		note.setMaxVisibility(TrainerRole.ROLE_TRAINER);
+		note.setType(NoteType.BATCH);
+		note.setQcFeedback(false);
+		
+		return note;
+	}
+	
+	/**
+	 * Factory method for creating a new Trainer weekly individual trainee note
+	 * 
+	 * @param content
+	 * @param week
+	 * @param traineeId
+	 * @return
+	 */
+	public static SimpleNote trainerIndividualNote(String content, Short week, Integer traineeId) {
+		SimpleNote note = new SimpleNote();
+		
+		note.setContent(content);
+		note.setWeek(week);
+		note.setTraineeId(traineeId);
+		note.setMaxVisibility(TrainerRole.ROLE_TRAINER);
+		note.setType(NoteType.TRAINEE);
+		note.setQcFeedback(false);
+		
+		return note;
+	}
+
+	public Integer getNoteId() {
+		return noteId;
+	}
+
+	public void setNoteId(Integer noteId) {
+		this.noteId = noteId;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	public Short getWeek() {
+		return week;
+	}
+
+	public void setWeek(Short week) {
+		this.week = week;
+	}
+
+	public Integer getBatchId() {
+		return batchId;
+	}
+
+	public void setBatchId(Integer batchId) {
+		this.batchId = batchId;
+	}
+
+	public Integer getTraineeId() {
+		return traineeId;
+	}
+
+	public void setTraineeId(Integer traineeId) {
+		this.traineeId = traineeId;
+	}
+
+	public TrainerRole getMaxVisibility() {
+		return maxVisibility;
+	}
+
+	public void setMaxVisibility(TrainerRole maxVisibility) {
+		this.maxVisibility = maxVisibility;
+	}
+
+	public NoteType getType() {
+		return type;
+	}
+
+	public void setType(NoteType type) {
+		this.type = type;
+	}
+
+	public boolean isQcFeedback() {
+		return qcFeedback;
+	}
+
+	public void setQcFeedback(boolean qcFeedback) {
+		this.qcFeedback = qcFeedback;
+	}
+
+	public QCStatus getQcStatus() {
+		return qcStatus;
+	}
+
+	public void setQcStatus(QCStatus qcStatus) {
+		this.qcStatus = qcStatus;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((batchId == null) ? 0 : batchId.hashCode());
+		result = prime * result + ((content == null) ? 0 : content.hashCode());
+		result = prime * result + ((maxVisibility == null) ? 0 : maxVisibility.hashCode());
+		result = prime * result + ((noteId == null) ? 0 : noteId.hashCode());
+		result = prime * result + (qcFeedback ? 1231 : 1237);
+		result = prime * result + ((qcStatus == null) ? 0 : qcStatus.hashCode());
+		result = prime * result + ((traineeId == null) ? 0 : traineeId.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		result = prime * result + ((week == null) ? 0 : week.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SimpleNote other = (SimpleNote) obj;
+		if (batchId == null) {
+			if (other.batchId != null)
+				return false;
+		} else if (!batchId.equals(other.batchId))
+			return false;
+		if (content == null) {
+			if (other.content != null)
+				return false;
+		} else if (!content.equals(other.content))
+			return false;
+		if (maxVisibility != other.maxVisibility)
+			return false;
+		if (noteId == null) {
+			if (other.noteId != null)
+				return false;
+		} else if (!noteId.equals(other.noteId))
+			return false;
+		if (qcFeedback != other.qcFeedback)
+			return false;
+		if (qcStatus != other.qcStatus)
+			return false;
+		if (traineeId == null) {
+			if (other.traineeId != null)
+				return false;
+		} else if (!traineeId.equals(other.traineeId))
+			return false;
+		if (type != other.type)
+			return false;
+		if (week == null) {
+			if (other.week != null)
+				return false;
+		} else if (!week.equals(other.week))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Note [noteId=" + noteId + ", content=" + content + ", week=" + week + ", batchId=" + batchId
+				+ ", traineeId=" + traineeId + ", maxVisibility=" + maxVisibility + ", type=" + type + ", qcFeedback="
+				+ qcFeedback + ", qcStatus=" + qcStatus + "]";
+	}
+	
+}

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/repository/NoteRepository.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/repository/NoteRepository.java
@@ -5,16 +5,16 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.revature.caliber.model.Note;
+import com.revature.caliber.model.SimpleNote;
 import com.revature.caliber.model.NoteType;
 
 @Repository
-public interface NoteRepository extends JpaRepository<Note, Integer> {
-	Note findByTraineeIdAndWeekAndQcFeedbackAndType(Integer traineeId, Short week, boolean qcFeedback, NoteType type);
+public interface NoteRepository extends JpaRepository<SimpleNote, Integer> {
+	SimpleNote findByTraineeIdAndWeekAndQcFeedbackAndType(Integer traineeId, Short week, boolean qcFeedback, NoteType type);
 	
-	List<Note> findByBatchIdAndType(Integer batchId, NoteType type);
-	List<Note> findByBatchIdAndWeekAndType(Integer batchId, Short week, NoteType type);
-	List<Note> findByTraineeIdAndType(Integer traineeId, NoteType type);
-	List<Note> findByBatchIdAndWeekAndQcFeedbackAndType(Integer batchId, Short week, boolean qcFeedback, NoteType type);
+	List<SimpleNote> findByBatchIdAndType(Integer batchId, NoteType type);
+	List<SimpleNote> findByBatchIdAndWeekAndType(Integer batchId, Short week, NoteType type);
+	List<SimpleNote> findByTraineeIdAndType(Integer traineeId, NoteType type);
+	List<SimpleNote> findByBatchIdAndWeekAndQcFeedbackAndType(Integer batchId, Short week, boolean qcFeedback, NoteType type);
 	
 }

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/service/NoteRepositoryMessagingService.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/service/NoteRepositoryMessagingService.java
@@ -7,8 +7,7 @@ import org.springframework.stereotype.Service;
 public class NoteRepositoryMessagingService {
 	
 	@RabbitListener(queues = "queue")
-	public String receive(String message) {
+	public void receive(String message) {
 		System.out.println(message);
-		return "NoteRepositoryMessagingService is ready";
 	}
 }

--- a/NoteRepositoryService/src/main/java/com/revature/caliber/service/NoteRepositoryMessagingService.java
+++ b/NoteRepositoryService/src/main/java/com/revature/caliber/service/NoteRepositoryMessagingService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class NoteRepositoryMessagingService {
 	
-	@RabbitListener(queues = "queue")
+	@RabbitListener(queues = "caliber.note")
 	public void receive(String message) {
 		System.out.println(message);
 	}

--- a/NoteRepositoryService/src/main/resources/application.properties
+++ b/NoteRepositoryService/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.h2.console.enabled=true
 spring.datasource.platform=h2
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=Oracle
 
-spring.rabbitmq.host=localhost
+spring.rabbitmq.host=ec2-35-168-22-185.compute-1.amazonaws.com
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest

--- a/NoteRepositoryService/src/main/resources/application.properties
+++ b/NoteRepositoryService/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.h2.console.enabled=true
 spring.datasource.platform=h2
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=Oracle
 
-spring.rabbitmq.host=ec2-35-168-22-185.compute-1.amazonaws.com
+spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest

--- a/NoteRepositoryService/src/test/java/com/revature/caliber/test/unit/NoteRepositoryTest.java
+++ b/NoteRepositoryService/src/test/java/com/revature/caliber/test/unit/NoteRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.revature.caliber.model.Note;
+import com.revature.caliber.model.SimpleNote;
 import com.revature.caliber.model.NoteType;
 import com.revature.caliber.model.QCStatus;
 import com.revature.caliber.repository.NoteRepository;
@@ -30,7 +30,7 @@ public class NoteRepositoryTest {
 	
 	@Test
 	public void findOneTest() {
-		Note note = noteRepository.findOne(5061);
+		SimpleNote note = noteRepository.findOne(5061);
 		short week = 2;
 		
 		System.out.println(note);
@@ -43,7 +43,7 @@ public class NoteRepositoryTest {
 	
 	@Test
 	public void findAllTest() {
-		List<Note> notes = noteRepository.findAll();
+		List<SimpleNote> notes = noteRepository.findAll();
 		
 		System.out.println(notes.size());
 		
@@ -54,12 +54,12 @@ public class NoteRepositoryTest {
 	 * Test method. Tests the findByBatchIdAndWeekAndQcFeedbackAndType method for findBatchNotes
 	 */
 	@Test
-	public void findByBatchIdAndWeekAndQcFeedbackAndTypeTest() {
+	public void findBatchNotesTest() {
 		short week = 2;
-		List<Note> notes = noteRepository.findByBatchIdAndWeekAndQcFeedbackAndType(TEST_BATCH_ID, week, false, NoteType.BATCH);
-		Note testNote = notes.get(0);
+		List<SimpleNote> notes = noteRepository.findByBatchIdAndWeekAndQcFeedbackAndType(TEST_BATCH_ID, week, false, NoteType.BATCH);
+		SimpleNote testNote = notes.get(0);
 		
-		System.out.println(notes);
+		System.out.println("Find batch notes:\n" + notes);
 		
 		assertFalse(notes.isEmpty());
 		assertEquals(TEST_BATCH_ID, testNote.getBatchId().intValue());
@@ -72,12 +72,12 @@ public class NoteRepositoryTest {
 	 * Test method. Tests the findByTraineeIdAndType method for findAllPublicIndividualNotes 
 	 */
 	@Test
-	public void findByTraineeIdAndTypeTest() {
+	public void findAllPublicIndividualNotesTest() {
 		short week = 1;
-		List<Note> notes = noteRepository.findByTraineeIdAndType(TEST_TRAINEE_ID, NoteType.TRAINEE);
-		Note testNote = notes.get(0);
+		List<SimpleNote> notes = noteRepository.findByTraineeIdAndType(TEST_TRAINEE_ID, NoteType.TRAINEE);
+		SimpleNote testNote = notes.get(0);
 		
-		System.out.println("Find By TraineeId and Type\n" + notes);
+		System.out.println("Find all public individual notes test:\n" + notes);
 		
 		assertFalse(notes.isEmpty());
 		assertNotNull(testNote);
@@ -92,11 +92,11 @@ public class NoteRepositoryTest {
 	 * Test method. Tests the findByTraineeIdAndWeekAndQcFeedbackAndType method for findTraineeNote 
 	 */
 	@Test
-	public void findByTraineeIdAndWeekAndQcFeedbackAndTypeTest() {
+	public void findTraineeNoteTest() {
 		short week = 2;
-		Note testNote = noteRepository.findByTraineeIdAndWeekAndQcFeedbackAndType(TEST_TRAINEE_ID, week, false, NoteType.TRAINEE);
+		SimpleNote testNote = noteRepository.findByTraineeIdAndWeekAndQcFeedbackAndType(TEST_TRAINEE_ID, week, false, NoteType.TRAINEE);
 		
-		System.out.println("Find By TraineeId and Week and qcFeedback and Type:\n" + testNote);
+		System.out.println("Find trainee note:\n" + testNote);
 		
 		assertNotNull(testNote);
 		assertEquals(week, testNote.getWeek().shortValue());
@@ -110,11 +110,11 @@ public class NoteRepositoryTest {
 	 * Test method. Tests the findByBatchIdAndType method for findAllBatchQCNotes  
 	 */
 	@Test
-	public void findByBatchIdAndTypeTest() {
-		List<Note> notes = noteRepository.findByBatchIdAndType(TEST_QC_BATCH_ID, NoteType.QC_BATCH);
-		Note testNote = notes.get(0);
+	public void findAllBatchQCNotesTest() {
+		List<SimpleNote> notes = noteRepository.findByBatchIdAndType(TEST_QC_BATCH_ID, NoteType.QC_BATCH);
+		SimpleNote testNote = notes.get(0);
 		
-		System.out.println("Find by BatchId and Type:\n" + testNote);
+		System.out.println("Find all batch QC notes:\n" + testNote);
 		
 		assertFalse(notes.isEmpty());
 		assertEquals(TEST_QC_BATCH_ID, testNote.getBatchId().intValue());
@@ -125,17 +125,29 @@ public class NoteRepositoryTest {
 	 * Test method. Tests the findByBatchIdAndWeekAndType method for findAllBatchNotes
 	 */
 	@Test
-	public void findByBatchIdAndWeekAndTypeTest() {
+	public void findAllBatchNotesTest() {
 		short week = 2;
-		List<Note> notes = noteRepository.findByBatchIdAndWeekAndType(TEST_BATCH_ID, week, NoteType.BATCH);
-		Note testNote = notes.get(0);
+		List<SimpleNote> notes = noteRepository.findByBatchIdAndWeekAndType(TEST_BATCH_ID, week, NoteType.BATCH);
+		SimpleNote testNote = notes.get(0);
 		
-		System.out.println("Find by BatchId and Week and Type:\n" + notes);
+		System.out.println("Find all batch notes:\n" + notes);
 		
 		assertFalse(notes.isEmpty());
 		assertEquals(NoteType.BATCH, testNote.getType());
 		assertEquals(week, testNote.getWeek().shortValue());
 		assertEquals(TEST_BATCH_ID, testNote.getBatchId().intValue());
+	}
+	
+	/**
+	 * Test method. Tests findByBatchIdAndWeekAndQcFeedbackAndType for findIndividualNotes
+	 */
+	public void findIndividualNotes() {
+		short week = 2;
+		List<SimpleNote> notes = noteRepository.findByBatchIdAndWeekAndQcFeedbackAndType(TEST_BATCH_ID, week, false, NoteType.TRAINEE);
+		
+		System.out.println("Find individual notes:\n" + notes);
+		
+		assertFalse(notes.isEmpty());
 	}
 
 }


### PR DESCRIPTION
Add relevant old beans to Note Composition Service.

Used a RestTemplate to communicate between NoteCompositionService and NoteRepositoryService. This should later be removed for messaging.

You should be able to run both NoteRepositoryService and NoteCompositionService. If you hit http://localhost:8182/note/{traineeId}/{week}, it will send a request to NoteRepositoryService, which returns a JSON (NoteCompositionService returns the same JSON for now).